### PR TITLE
Fixed world scale.

### DIFF
--- a/src/spinecpp/Bone.cpp
+++ b/src/spinecpp/Bone.cpp
@@ -247,12 +247,12 @@ float Bone::getWorldRotationY() const
 
 float Bone::getWorldScaleX() const
 {
-    return sqrt(a * a + b * b) * worldSign.x;
+    return sqrt(a * a + c * c) * worldSign.x;
 }
 
 float Bone::getWorldScaleY() const
 {
-    return sqrt(c * c + d * d) * worldSign.y;
+    return sqrt(b * b + d * d) * worldSign.y;
 }
 
 float Bone::worldToLocalRotationX() const


### PR DESCRIPTION
World scale is approximated by the magnitudes of the i (a,c) and j (b,d) vectors of the bone matrix.
based on : https://github.com/EsotericSoftware/spine-runtimes/commit/6cc91d579cb0e0f1b51fd9c3fbe748ad066d32d8
